### PR TITLE
improve plugin sanitation

### DIFF
--- a/destroyer.js
+++ b/destroyer.js
@@ -40,6 +40,8 @@
     event.preventDefault();
     var el = event.target;
     el.parentNode.removeChild(el);
+    mask.style.height = '0';
+    mask.style.width = '0';
   };
   var keydown = function keydown(event) {
     if (event.keyCode === 27)

--- a/destroyer.js
+++ b/destroyer.js
@@ -1,6 +1,6 @@
 (function() {
-  if (window.__global_dom_destroyer_stop) {
-    window.__global_dom_destroyer_stop();
+  if (window.show_mercy) {
+    window.show_mercy();
     return;
   }
 
@@ -26,7 +26,7 @@
     return {left: left, top: top};
   };
 
-  var mouseover = function mouseover(event) {
+  var change_target = function change_target(event) {
     var el = event.target;
     var offset = page_offset(el);
     mask.style.width = el.offsetWidth + 'px';
@@ -43,29 +43,28 @@
     mask.style.height = '0';
     mask.style.width = '0';
   };
-  var keydown = function keydown(event) {
+  var maybe_show_mercy = function keydown(event) {
     if (event.keyCode === 27)
       stop_destroying();
   };
 
-  var stop_destroying = function stop_destroying() {
-    console.log('stopping');
+  var show_mercy = function show_mercy() {
     document.body.removeChild(mask);
-    document.removeEventListener('mouseover', mouseover);
+    document.removeEventListener('mouseover', change_target);
     document.removeEventListener('click', destroy);
-    document.removeEventListener('keydown', keydown);
+    document.removeEventListener('keydown', maybe_show_mercy);
 
-    window.__global_dom_destroyer_stop = null;
+    window.show_mercy = null;
   };
 
-  var start_destroying = function start_destroying() {
+  var arm_destroyer = function arm_destroyer() {
     document.body.appendChild(mask);
-    document.addEventListener('mouseover', mouseover);
+    document.addEventListener('mouseover', change_target);
     document.addEventListener('click', destroy);
-    document.addEventListener('keydown', keydown);
+    document.addEventListener('keydown', maybe_show_mercy);
 
-    window.__global_dom_destroyer_stop = stop_destroying;
+    window.show_mercy = show_mercy;
   };
 
-  start_destroying();
+  arm_destroyer();
 })();

--- a/destroyer.js
+++ b/destroyer.js
@@ -1,4 +1,8 @@
 (function() {
+  if (window.__global_dom_destroyer_active)
+    return;
+
+  window.__global_dom_destroyer_active = true;
 
   var mask = document.createElement('div');
   mask.style.pointerEvents = 'none';
@@ -47,6 +51,8 @@
     document.removeEventListener('mouseover', mouseover);
     document.removeEventListener('click', destroy);
     document.removeEventListener('keydown', keydown);
+
+    window.__global_dom_destroyer_active = false;
   };
 
   var start_destroying = function start_destroying() {

--- a/destroyer.js
+++ b/destroyer.js
@@ -1,6 +1,5 @@
 (function() {
 
-  var listeners = [];
   var mask = document.createElement('div');
   mask.style.pointerEvents = 'none';
   mask.style.position = 'absolute';
@@ -37,22 +36,24 @@
     event.preventDefault();
     var el = event.target;
     el.parentNode.removeChild(el);
-    mask.style.height = '0';
-    mask.style.width = '0';
   };
-  var escape = function() {
-    document.body.removeChild(mask);
+  var keydown = function(event) {
+    if (event.keyCode === 27)
+      stop_destroying();
   };
 
-  window.start_destroying = function start_destroying() {
-    document.querySelector('body').appendChild(mask);
-    listeners.push(document.addEventListener('mouseover', mouseover));
-    listeners.push(document.addEventListener('click', destroy));
-    listeners.push(document.addEventListener('keydown', function(event) {
-      if (event.keyCode === 27) {
-        escape();
-      }
-    }));
+  var stop_destroying = function() {
+    document.body.removeChild(mask);
+    document.removeEventListener('mouseover', mouseover);
+    document.removeEventListener('click', destroy);
+    document.removeEventListener('keydown', keydown);
+  };
+
+  var start_destroying = function start_destroying() {
+    document.body.appendChild(mask);
+    document.addEventListener('mouseover', mouseover);
+    document.addEventListener('click', destroy);
+    document.addEventListener('keydown', keydown);
   };
 
   start_destroying();

--- a/destroyer.js
+++ b/destroyer.js
@@ -1,8 +1,8 @@
 (function() {
-  if (window.__global_dom_destroyer_active)
+  if (window.__global_dom_destroyer_stop) {
+    window.__global_dom_destroyer_stop();
     return;
-
-  window.__global_dom_destroyer_active = true;
+  }
 
   var mask = document.createElement('div');
   mask.style.pointerEvents = 'none';
@@ -26,7 +26,7 @@
     return {left: left, top: top};
   };
 
-  var mouseover = function(event) {
+  var mouseover = function mouseover(event) {
     var el = event.target;
     var offset = page_offset(el);
     mask.style.width = el.offsetWidth + 'px';
@@ -34,25 +34,26 @@
     mask.style.height = el.offsetHeight + 'px';
     mask.style.top = offset.top + 'px';
   };
-  var destroy = function(event) {
+  var destroy = function destroy(event) {
     event.stopImmediatePropagation();
     event.stopPropagation();
     event.preventDefault();
     var el = event.target;
     el.parentNode.removeChild(el);
   };
-  var keydown = function(event) {
+  var keydown = function keydown(event) {
     if (event.keyCode === 27)
       stop_destroying();
   };
 
-  var stop_destroying = function() {
+  var stop_destroying = function stop_destroying() {
+    console.log('stopping');
     document.body.removeChild(mask);
     document.removeEventListener('mouseover', mouseover);
     document.removeEventListener('click', destroy);
     document.removeEventListener('keydown', keydown);
 
-    window.__global_dom_destroyer_active = false;
+    window.__global_dom_destroyer_stop = null;
   };
 
   var start_destroying = function start_destroying() {
@@ -60,6 +61,8 @@
     document.addEventListener('mouseover', mouseover);
     document.addEventListener('click', destroy);
     document.addEventListener('keydown', keydown);
+
+    window.__global_dom_destroyer_stop = stop_destroying;
   };
 
   start_destroying();


### PR DESCRIPTION
Made the plugin clean up after itself better, and ensured that multiple instances of the plugin are not running on a single page at the same time. Also made pressing the button a second time stop the dom-destroyer.

I'm pretty sure that the `__global_dom_destroyer_stop` property doesn't need to have such a long name, as the plugin runs in a separate javascript environment from the rest of the page, only sharing the DOM, but I am not 100% confident, and this works.

I could have made future launches of the plugin use the same handler functions etc. as past launches, however, it would be mildly more difficult, and they will be garbage collected in the current situation anyway.
